### PR TITLE
Feature 28/user proceeds without adding a new family members

### DIFF
--- a/src/components/atom/AppPopupAlert.tsx
+++ b/src/components/atom/AppPopupAlert.tsx
@@ -1,0 +1,57 @@
+import {widthSwalCalculation} from "../../helpers";
+import Swal, {SweetAlertIcon} from "sweetalert2";
+
+interface PopupAlertProps {
+    icon: SweetAlertIcon;
+    title: string;
+    confirmButtonText: string;
+    text?: string;
+    cancelButtonText?: string;
+}
+
+export default ({
+                    icon,
+                    title,
+                    text,
+                    confirmButtonText,
+                    cancelButtonText,
+                }: PopupAlertProps) => {
+
+    const isWarning = icon === "warning";
+    const confirmButtonColor = isWarning ? 'warning-color' : 'primary-color';
+    const cancelButtonColor = isWarning ? 'primary-color' : 'warning-color';
+    const handleTwoButtons = {
+        confirmButton: `bg-${confirmButtonColor} hover-${confirmButtonColor} focus-${confirmButtonColor} text-white
+                rounded-2xl font-button w-full lg:w-2/5 focus:outline-none focus:ring-1 focus:ring-offset-1 h-16`,
+        cancelButton: `bg-${cancelButtonColor} hover-${cancelButtonColor} focus-${cancelButtonColor} text-white
+                rounded-2xl font-button w-full lg:w-2/5 focus:outline-none focus:ring-1 focus:ring-offset-1 h-16`,
+    }
+    const handleOneButton = {
+        confirmButton: `bg-${confirmButtonColor} hover-${confirmButtonColor} focus-${confirmButtonColor} text-white
+                rounded-2xl font-button w-full focus:outline-none focus:ring-1 focus:ring-offset-1 h-16`,
+    }
+
+    return Swal.mixin({
+        position: 'bottom',
+        padding: '1rem',
+        buttonsStyling: false,
+        title,
+        text,
+        icon,
+        iconColor: (isWarning ? '#EB5757' : '#2D7DB5'),
+        showCancelButton: !!cancelButtonText,
+        confirmButtonText,
+        cancelButtonText,
+        reverseButtons: isWarning,
+        focusCancel: isWarning,
+        customClass: {
+            popup: 'rounded-2xl',
+            actions: 'flex gap-2 w-full',
+            title: 'font-big-title text-secondary-color',
+            htmlContainer: 'text-left font-text text-secondary-color',
+            confirmButton: isWarning ? handleTwoButtons.confirmButton : handleOneButton.confirmButton,
+            cancelButton: isWarning ? handleTwoButtons.cancelButton : handleOneButton.confirmButton,
+        },
+        width: widthSwalCalculation(parent.innerWidth),
+    });
+};

--- a/src/helpers/index.ts
+++ b/src/helpers/index.ts
@@ -1,2 +1,3 @@
 export {default as validateDNI} from "./validateDNI";
 export {default as validateNIE} from "./validateNIE";
+export {default as widthSwalCalculation} from "./widthSwalCalculation";

--- a/src/helpers/widthSwalCalculation.ts
+++ b/src/helpers/widthSwalCalculation.ts
@@ -1,0 +1,10 @@
+export default (parentWidth: number): string => {
+    if (parentWidth < 768) {
+        return 'w-1/2';
+    } else if (parentWidth < 1024) {
+        return 'w-1/4';
+    } else {
+        return 'w-1/8';
+    }
+};
+

--- a/src/hooks/useLoginPasswordRecovery.ts
+++ b/src/hooks/useLoginPasswordRecovery.ts
@@ -31,12 +31,12 @@ const useLoginPasswordRecovery = <T extends string>(initialState: T) => {
             position: 'bottom',
             padding: '1rem',
             customClass: {
-                popup: "rounded-md",
-                title: "font-big-title",
+                popup: "rounded-2xl",
+                title: "font-big-title text-secondary-color",
                 actions: "w-full",
-                htmlContainer: "text-left font-text",
+                htmlContainer: "text-left font-text text-secondary-color",
                 confirmButton: "bg-primary-color hover-primary-color text-white rounded-xl font-button w-full" +
-                    " focus:outline-none focus:ring-1 focus:ring-offset-1 focus-primary-color h-20",
+                    " focus:outline-none focus:ring-1 focus:ring-offset-1 focus-primary-color h-16",
             },
             width: parent.innerWidth < 768 ? '95%' : parent.innerWidth < 1024 ? '48%' : '35%',
         }).then(() => navigate('/login'));

--- a/src/hooks/useLoginPasswordRecovery.ts
+++ b/src/hooks/useLoginPasswordRecovery.ts
@@ -1,10 +1,9 @@
 import {ChangeEvent, FormEvent, useState} from "react";
 import {useNavigate} from "react-router-dom";
 import {useTranslation} from "react-i18next";
-import Swal from 'sweetalert2'
 import usersMock from "../mocks/users.mock";
 import {namespaces} from "../i18n/i18n.constants";
-import {widthSwalCalculation} from "../helpers";
+import AppPopupAlert from "../components/atom/AppPopupAlert";
 
 const useLoginPasswordRecovery = <T extends string>(initialState: T) => {
     const [email, setEmail] = useState<T>(initialState);
@@ -22,25 +21,14 @@ const useLoginPasswordRecovery = <T extends string>(initialState: T) => {
     const onSubmit = (e: FormEvent<HTMLFormElement>) => {
         e.preventDefault();
         setHasError(!isFormValid(email));
-        if (isFormValid(email)) Swal.fire({
-            title: t("sweetAlert.title") as string,
-            text: t("sweetAlert.description") as string,
-            icon: 'success',
-            iconColor: '#0F95CE',
-            confirmButtonText: t("sweetAlert.confirm") as string,
-            buttonsStyling: false,
-            position: 'bottom',
-            padding: '1rem',
-            customClass: {
-                popup: "rounded-2xl",
-                title: "font-big-title text-secondary-color",
-                actions: "w-full",
-                htmlContainer: "text-left font-text text-secondary-color",
-                confirmButton: "bg-primary-color hover-primary-color text-white rounded-xl font-button w-full" +
-                    " focus:outline-none focus:ring-1 focus:ring-offset-1 focus-primary-color h-16",
-            },
-            width: widthSwalCalculation(parent.innerWidth),
-        }).then(() => navigate('/login'));
+        if (isFormValid(email)) {
+            AppPopupAlert({
+                icon: 'success',
+                title: t("sweetAlert.title") as string,
+                text: t("sweetAlert.description") as string,
+                confirmButtonText: t("sweetAlert.confirm") as string,
+            }).fire().then(() => navigate('/login'));
+        }
     }
 
     return {

--- a/src/hooks/useLoginPasswordRecovery.ts
+++ b/src/hooks/useLoginPasswordRecovery.ts
@@ -4,6 +4,7 @@ import {useTranslation} from "react-i18next";
 import Swal from 'sweetalert2'
 import usersMock from "../mocks/users.mock";
 import {namespaces} from "../i18n/i18n.constants";
+import {widthSwalCalculation} from "../helpers";
 
 const useLoginPasswordRecovery = <T extends string>(initialState: T) => {
     const [email, setEmail] = useState<T>(initialState);
@@ -38,7 +39,7 @@ const useLoginPasswordRecovery = <T extends string>(initialState: T) => {
                 confirmButton: "bg-primary-color hover-primary-color text-white rounded-xl font-button w-full" +
                     " focus:outline-none focus:ring-1 focus:ring-offset-1 focus-primary-color h-16",
             },
-            width: parent.innerWidth < 768 ? '95%' : parent.innerWidth < 1024 ? '48%' : '35%',
+            width: widthSwalCalculation(parent.innerWidth),
         }).then(() => navigate('/login'));
     }
 

--- a/src/hooks/useMenuDeleteAccount.ts
+++ b/src/hooks/useMenuDeleteAccount.ts
@@ -22,13 +22,14 @@ const useMenuDeleteAccount = () => {
             reverseButtons: true,
             focusCancel: true,
             customClass: {
-                popup: "rounded-md",
+                popup: "rounded-2xl",
                 actions: "flex gap-2 w-full",
-                title: "font-big-title",
+                title: "font-big-title text-secondary-color",
+                htmlContainer: "text-left font-text text-secondary-color",
                 confirmButton: "bg-warning-color hover-warning-color text-white rounded-xl font-button w-full" +
-                    " lg:w-2/5 focus:outline-none focus:ring-1 focus:ring-offset-1 focus-warning-color h-20",
+                    " lg:w-2/5 focus:outline-none focus:ring-1 focus:ring-offset-1 focus-warning-color h-16",
                 cancelButton: "bg-primary-color hover-primary-color text-white rounded-xl font-button w-full" +
-                    " lg:w-2/5 focus:outline-none focus:ring-1 focus:ring-offset-1 focus-primary-color h-20",
+                    " lg:w-2/5 focus:outline-none focus:ring-1 focus:ring-offset-1 focus-primary-color h-16",
             },
             width: parent.innerWidth < 768 ? '95%' : parent.innerWidth < 1024 ? '48%' : '35%',
         }).then((result) => {
@@ -43,11 +44,12 @@ const useMenuDeleteAccount = () => {
                     position: 'bottom',
                     padding: '1rem',
                     customClass: {
-                        popup: "rounded-md",
+                        popup: "rounded-2xl",
                         actions: "w-full",
-                        title: "text-big-title",
+                        title: "text-big-title text-secondary-color",
+                        htmlContainer: "text-left font-text text-secondary-color",
                         confirmButton: "bg-primary-color hover-primary-color text-white rounded-xl font-button w-full" +
-                            " lg:w-2/5 focus:outline-none focus:ring-1 focus:ring-offset-1 focus-primary-color h-20",
+                            " lg:w-2/5 focus:outline-none focus:ring-1 focus:ring-offset-1 focus-primary-color h-16",
                     },
                     width: parent.innerWidth < 768 ? '95%' : parent.innerWidth < 1024 ? '48%' : '35%',
                 }).then(() => navigate('/login'));

--- a/src/hooks/useMenuDeleteAccount.ts
+++ b/src/hooks/useMenuDeleteAccount.ts
@@ -1,59 +1,27 @@
 import {useTranslation} from "react-i18next";
 import {useNavigate} from "react-router-dom";
-import Swal from "sweetalert2";
 import {namespaces} from "../i18n/i18n.constants";
-import {widthSwalCalculation} from "../helpers";
+import AppPopupAlert from "../components/atom/AppPopupAlert";
 
 const useMenuDeleteAccount = () => {
     const {t} = useTranslation(namespaces.pages.menuDeleteAccount);
     const navigate = useNavigate();
 
     const handleDeleteAccount = () => {
-        Swal.fire({
-            showCancelButton: true,
+        AppPopupAlert({
+            icon: 'warning',
             title: t("title") as string,
             text: t("description") as string,
             confirmButtonText: t("deleteAccount") as string,
             cancelButtonText: t("cancel") as string,
-            icon: 'warning',
-            iconColor: '#EB5757',
-            buttonsStyling: false,
-            position: 'bottom',
-            padding: '1rem',
-            reverseButtons: true,
-            focusCancel: true,
-            customClass: {
-                popup: "rounded-2xl",
-                actions: "flex gap-2 w-full",
-                title: "font-big-title text-secondary-color",
-                htmlContainer: "text-left font-text text-secondary-color",
-                confirmButton: "bg-warning-color hover-warning-color text-white rounded-xl font-button w-full" +
-                    " lg:w-2/5 focus:outline-none focus:ring-1 focus:ring-offset-1 focus-warning-color h-16",
-                cancelButton: "bg-primary-color hover-primary-color text-white rounded-xl font-button w-full" +
-                    " lg:w-2/5 focus:outline-none focus:ring-1 focus:ring-offset-1 focus-primary-color h-16",
-            },
-            width: widthSwalCalculation(parent.innerWidth),
-        }).then((result) => {
+        }).fire().then((result) => {
             if (result.isConfirmed) {
-                Swal.fire({
+                AppPopupAlert({
+                    icon: 'success',
                     title: t("deleteAccountSuccess") as string,
                     text: t("deleteAccountSuccessDescription") as string,
                     confirmButtonText: t("deleteAccountSuccessButton") as string,
-                    icon: 'success',
-                    iconColor: '#3085d6',
-                    buttonsStyling: false,
-                    position: 'bottom',
-                    padding: '1rem',
-                    customClass: {
-                        popup: "rounded-2xl",
-                        actions: "w-full",
-                        title: "text-big-title text-secondary-color",
-                        htmlContainer: "text-left font-text text-secondary-color",
-                        confirmButton: "bg-primary-color hover-primary-color text-white rounded-xl font-button w-full" +
-                            " lg:w-2/5 focus:outline-none focus:ring-1 focus:ring-offset-1 focus-primary-color h-16",
-                    },
-                    width: widthSwalCalculation(parent.innerWidth),
-                }).then(() => navigate('/login'));
+                }).fire().then(() => navigate('/login'));
             }
         });
     };

--- a/src/hooks/useMenuDeleteAccount.ts
+++ b/src/hooks/useMenuDeleteAccount.ts
@@ -2,6 +2,7 @@ import {useTranslation} from "react-i18next";
 import {useNavigate} from "react-router-dom";
 import Swal from "sweetalert2";
 import {namespaces} from "../i18n/i18n.constants";
+import {widthSwalCalculation} from "../helpers";
 
 const useMenuDeleteAccount = () => {
     const {t} = useTranslation(namespaces.pages.menuDeleteAccount);
@@ -31,7 +32,7 @@ const useMenuDeleteAccount = () => {
                 cancelButton: "bg-primary-color hover-primary-color text-white rounded-xl font-button w-full" +
                     " lg:w-2/5 focus:outline-none focus:ring-1 focus:ring-offset-1 focus-primary-color h-16",
             },
-            width: parent.innerWidth < 768 ? '95%' : parent.innerWidth < 1024 ? '48%' : '35%',
+            width: widthSwalCalculation(parent.innerWidth),
         }).then((result) => {
             if (result.isConfirmed) {
                 Swal.fire({
@@ -51,7 +52,7 @@ const useMenuDeleteAccount = () => {
                         confirmButton: "bg-primary-color hover-primary-color text-white rounded-xl font-button w-full" +
                             " lg:w-2/5 focus:outline-none focus:ring-1 focus:ring-offset-1 focus-primary-color h-16",
                     },
-                    width: parent.innerWidth < 768 ? '95%' : parent.innerWidth < 1024 ? '48%' : '35%',
+                    width: widthSwalCalculation(parent.innerWidth),
                 }).then(() => navigate('/login'));
             }
         });

--- a/src/hooks/useProfileEditEmail.ts
+++ b/src/hooks/useProfileEditEmail.ts
@@ -4,6 +4,7 @@ import {useTranslation} from "react-i18next";
 import Swal from 'sweetalert2'
 import usersMock from "../mocks/users.mock";
 import {namespaces} from "../i18n/i18n.constants";
+import {widthSwalCalculation} from "../helpers";
 
 const useProfileEditEmail = <T extends string>(initialState: T) => {
     const [email, setEmail] = useState<T>(initialState);
@@ -50,7 +51,7 @@ const useProfileEditEmail = <T extends string>(initialState: T) => {
                 cancelButton: "bg-primary-color hover-primary-color text-white rounded-xl font-button w-full" +
                     " lg:w-2/5 focus:outline-none focus:ring-1 focus:ring-offset-1 focus-primary-color h-16",
             },
-            width: parent.innerWidth < 768 ? '95%' : parent.innerWidth < 1024 ? '48%' : '35%',
+            width: widthSwalCalculation(parent.innerWidth),
 
         }).then((result) => {
             if (result.isConfirmed) {
@@ -69,7 +70,7 @@ const useProfileEditEmail = <T extends string>(initialState: T) => {
                         confirmButton: "bg-primary-color hover-primary-color text-white rounded-xl font-button w-full" +
                             " lg:w-2/5 focus:outline-none focus:ring-1 focus:ring-offset-1 focus-primary-color h-16",
                     },
-                    width: parent.innerWidth < 768 ? '95%' : parent.innerWidth < 1024 ? '48%' : '35%',
+                    width: widthSwalCalculation(parent.innerWidth),
                 }).then(() => navigate('/profile'))
             }
         })

--- a/src/hooks/useProfileEditEmail.ts
+++ b/src/hooks/useProfileEditEmail.ts
@@ -1,10 +1,9 @@
 import {ChangeEvent, FormEvent, useState} from "react";
 import {useNavigate} from 'react-router-dom';
 import {useTranslation} from "react-i18next";
-import Swal from 'sweetalert2'
 import usersMock from "../mocks/users.mock";
 import {namespaces} from "../i18n/i18n.constants";
-import {widthSwalCalculation} from "../helpers";
+import AppPopupAlert from "../components/atom/AppPopupAlert";
 
 const useProfileEditEmail = <T extends string>(initialState: T) => {
     const [email, setEmail] = useState<T>(initialState);
@@ -30,50 +29,22 @@ const useProfileEditEmail = <T extends string>(initialState: T) => {
     const onSubmit = (e: FormEvent<HTMLFormElement>) => {
         e.preventDefault();
         setHasError(!validateEmail(email));
-        if (validateEmail(email)) Swal.fire({
-            showCancelButton: true,
-            title: t("sweetAlert.title") as string,
-            confirmButtonText: t("sweetAlert.confirmButtonText") as string,
-            cancelButtonText: t("sweetAlert.cancelButtonText") as string,
-            icon: 'warning',
-            iconColor: '#EB5757',
-            buttonsStyling: false,
-            position: 'bottom',
-            padding: '1rem',
-            reverseButtons: true,
-            focusCancel: true,
-            customClass: {
-                popup: "rounded-2xl",
-                actions: "flex gap-2 w-full",
-                title: "font-big-title text-secondary-color",
-                confirmButton: "bg-warning-color hover-warning-color text-white rounded-xl font-button w-full" +
-                    " lg:w-2/5 focus:outline-none focus:ring-1 focus:ring-offset-1 focus-warning-color h-16",
-                cancelButton: "bg-primary-color hover-primary-color text-white rounded-xl font-button w-full" +
-                    " lg:w-2/5 focus:outline-none focus:ring-1 focus:ring-offset-1 focus-primary-color h-16",
-            },
-            width: widthSwalCalculation(parent.innerWidth),
-
-        }).then((result) => {
-            if (result.isConfirmed) {
-                Swal.fire({
-                    title: t("sweetAlertSuccess.title") as string,
-                    confirmButtonText: t("sweetAlertSuccess.confirmButtonText") as string,
-                    icon: 'success',
-                    iconColor: '#3085d6',
-                    buttonsStyling: false,
-                    position: 'bottom',
-                    padding: '1rem',
-                    customClass: {
-                        popup: "rounded-2xl",
-                        actions: "w-full",
-                        title: "text-big-title text-secondary-color",
-                        confirmButton: "bg-primary-color hover-primary-color text-white rounded-xl font-button w-full" +
-                            " lg:w-2/5 focus:outline-none focus:ring-1 focus:ring-offset-1 focus-primary-color h-16",
-                    },
-                    width: widthSwalCalculation(parent.innerWidth),
-                }).then(() => navigate('/profile'))
-            }
-        })
+        if (validateEmail(email)) {
+            AppPopupAlert({
+                icon: 'warning',
+                title: t("sweetAlert.title") as string,
+                confirmButtonText: t("sweetAlert.confirmButtonText") as string,
+                cancelButtonText: t("sweetAlert.cancelButtonText") as string,
+            }).fire().then((result) => {
+                if (result.isConfirmed) {
+                    AppPopupAlert({
+                        icon: 'success',
+                        title: t("sweetAlertSuccess.title") as string,
+                        confirmButtonText: t("sweetAlertSuccess.confirmButtonText") as string,
+                    }).fire().then(() => navigate('/profile'))
+                }
+            })
+        }
     }
 
     return {

--- a/src/hooks/useProfileEditEmail.ts
+++ b/src/hooks/useProfileEditEmail.ts
@@ -42,13 +42,13 @@ const useProfileEditEmail = <T extends string>(initialState: T) => {
             reverseButtons: true,
             focusCancel: true,
             customClass: {
-                popup: "rounded-md",
+                popup: "rounded-2xl",
                 actions: "flex gap-2 w-full",
-                title: "font-big-title",
+                title: "font-big-title text-secondary-color",
                 confirmButton: "bg-warning-color hover-warning-color text-white rounded-xl font-button w-full" +
-                    " lg:w-2/5 focus:outline-none focus:ring-1 focus:ring-offset-1 focus-warning-color h-20",
+                    " lg:w-2/5 focus:outline-none focus:ring-1 focus:ring-offset-1 focus-warning-color h-16",
                 cancelButton: "bg-primary-color hover-primary-color text-white rounded-xl font-button w-full" +
-                    " lg:w-2/5 focus:outline-none focus:ring-1 focus:ring-offset-1 focus-primary-color h-20",
+                    " lg:w-2/5 focus:outline-none focus:ring-1 focus:ring-offset-1 focus-primary-color h-16",
             },
             width: parent.innerWidth < 768 ? '95%' : parent.innerWidth < 1024 ? '48%' : '35%',
 
@@ -63,11 +63,11 @@ const useProfileEditEmail = <T extends string>(initialState: T) => {
                     position: 'bottom',
                     padding: '1rem',
                     customClass: {
-                        popup: "rounded-md",
+                        popup: "rounded-2xl",
                         actions: "w-full",
-                        title: "text-big-title",
+                        title: "text-big-title text-secondary-color",
                         confirmButton: "bg-primary-color hover-primary-color text-white rounded-xl font-button w-full" +
-                            " lg:w-2/5 focus:outline-none focus:ring-1 focus:ring-offset-1 focus-primary-color h-20",
+                            " lg:w-2/5 focus:outline-none focus:ring-1 focus:ring-offset-1 focus-primary-color h-16",
                     },
                     width: parent.innerWidth < 768 ? '95%' : parent.innerWidth < 1024 ? '48%' : '35%',
                 }).then(() => navigate('/profile'))

--- a/src/hooks/useProfileEditNewPassword.ts
+++ b/src/hooks/useProfileEditNewPassword.ts
@@ -3,6 +3,7 @@ import {useNavigate} from "react-router-dom";
 import {useTranslation} from "react-i18next";
 import Swal from 'sweetalert2'
 import {namespaces} from "../i18n/i18n.constants";
+import {widthSwalCalculation} from "../helpers";
 
 const useProfileEditNewPassword = () => {
     const [password, setPassword] = useState<string>('');
@@ -45,7 +46,7 @@ const useProfileEditNewPassword = () => {
                 cancelButton: "bg-primary-color hover-primary-color text-white rounded-xl font-button w-full" +
                     " lg:w-2/5 focus:outline-none focus:ring-1 focus:ring-offset-1 focus-primary-color h-16",
             },
-            width: parent.innerWidth < 768 ? '95%' : parent.innerWidth < 1024 ? '48%' : '35%',
+            width: widthSwalCalculation(parent.innerWidth),
 
         }).then((result) => {
             if (result.isConfirmed) {
@@ -64,7 +65,7 @@ const useProfileEditNewPassword = () => {
                         confirmButton: "bg-primary-color hover-primary-color text-white rounded-xl font-button w-full" +
                             " focus:outline-none focus:ring-1 focus:ring-offset-1 focus-primary-color h-16",
                     },
-                    width: parent.innerWidth < 768 ? '95%' : parent.innerWidth < 1024 ? '48%' : '35%',
+                    width: widthSwalCalculation(parent.innerWidth),
                 }).then(() => navigate('/profile'));
             }
         })

--- a/src/hooks/useProfileEditNewPassword.ts
+++ b/src/hooks/useProfileEditNewPassword.ts
@@ -37,13 +37,13 @@ const useProfileEditNewPassword = () => {
             padding: '1rem',
             focusCancel: true,
             customClass: {
-                popup: "rounded-md",
+                popup: "rounded-2xl",
                 actions: "flex gap-2 w-full",
-                title: "font-big-title",
+                title: "font-big-title text-secondary-color",
                 confirmButton: "bg-warning-color hover-warning-color text-white rounded-xl font-button w-full" +
-                    " lg:w-2/5 focus:outline-none focus:ring-1 focus:ring-offset-1 focus-warning-color h-20",
+                    " lg:w-2/5 focus:outline-none focus:ring-1 focus:ring-offset-1 focus-warning-color h-16",
                 cancelButton: "bg-primary-color hover-primary-color text-white rounded-xl font-button w-full" +
-                    " lg:w-2/5 focus:outline-none focus:ring-1 focus:ring-offset-1 focus-primary-color h-20",
+                    " lg:w-2/5 focus:outline-none focus:ring-1 focus:ring-offset-1 focus-primary-color h-16",
             },
             width: parent.innerWidth < 768 ? '95%' : parent.innerWidth < 1024 ? '48%' : '35%',
 
@@ -58,11 +58,11 @@ const useProfileEditNewPassword = () => {
                     position: 'bottom',
                     padding: '1rem',
                     customClass: {
-                        popup: "rounded-md",
+                        popup: "rounded-2xl",
                         actions: "w-full",
-                        title: "font-big-title",
+                        title: "font-big-title text-secondary-color",
                         confirmButton: "bg-primary-color hover-primary-color text-white rounded-xl font-button w-full" +
-                            " focus:outline-none focus:ring-1 focus:ring-offset-1 focus-primary-color h-20",
+                            " focus:outline-none focus:ring-1 focus:ring-offset-1 focus-primary-color h-16",
                     },
                     width: parent.innerWidth < 768 ? '95%' : parent.innerWidth < 1024 ? '48%' : '35%',
                 }).then(() => navigate('/profile'));

--- a/src/hooks/useProfileEditNewPassword.ts
+++ b/src/hooks/useProfileEditNewPassword.ts
@@ -1,9 +1,8 @@
 import {ChangeEvent, FormEvent, useState} from "react";
 import {useNavigate} from "react-router-dom";
 import {useTranslation} from "react-i18next";
-import Swal from 'sweetalert2'
 import {namespaces} from "../i18n/i18n.constants";
-import {widthSwalCalculation} from "../helpers";
+import AppPopupAlert from "../components/atom/AppPopupAlert";
 
 const useProfileEditNewPassword = () => {
     const [password, setPassword] = useState<string>('');
@@ -25,52 +24,23 @@ const useProfileEditNewPassword = () => {
     const onSubmit = (e: FormEvent<HTMLFormElement>) => {
         e.preventDefault();
         setHasError(!arePasswordsEqual);
-        if (arePasswordsEqual) Swal.fire({
-            showCancelButton: true,
-            title: t('sweetAlert.title') as string,
-            confirmButtonText: t('sweetAlert.confirmButtonText') as string,
-            cancelButtonText: t('sweetAlert.cancelButtonText') as string,
-            icon: 'warning',
-            iconColor: '#EB5757',
-            buttonsStyling: false,
-            position: 'bottom',
-            reverseButtons: true,
-            padding: '1rem',
-            focusCancel: true,
-            customClass: {
-                popup: "rounded-2xl",
-                actions: "flex gap-2 w-full",
-                title: "font-big-title text-secondary-color",
-                confirmButton: "bg-warning-color hover-warning-color text-white rounded-xl font-button w-full" +
-                    " lg:w-2/5 focus:outline-none focus:ring-1 focus:ring-offset-1 focus-warning-color h-16",
-                cancelButton: "bg-primary-color hover-primary-color text-white rounded-xl font-button w-full" +
-                    " lg:w-2/5 focus:outline-none focus:ring-1 focus:ring-offset-1 focus-primary-color h-16",
-            },
-            width: widthSwalCalculation(parent.innerWidth),
-
-        }).then((result) => {
-            if (result.isConfirmed) {
-                Swal.fire({
-                    title: t('sweetAlertSuccess.title') as string,
-                    confirmButtonText: t('sweetAlertSuccess.confirmButtonText') as string,
-                    icon: 'success',
-                    iconColor: '#3085d6',
-                    buttonsStyling: false,
-                    position: 'bottom',
-                    padding: '1rem',
-                    customClass: {
-                        popup: "rounded-2xl",
-                        actions: "w-full",
-                        title: "font-big-title text-secondary-color",
-                        confirmButton: "bg-primary-color hover-primary-color text-white rounded-xl font-button w-full" +
-                            " focus:outline-none focus:ring-1 focus:ring-offset-1 focus-primary-color h-16",
-                    },
-                    width: widthSwalCalculation(parent.innerWidth),
-                }).then(() => navigate('/profile'));
-            }
-        })
+        if (arePasswordsEqual) {
+            AppPopupAlert({
+                icon: 'warning',
+                title: t("sweetAlert.title") as string,
+                confirmButtonText: t("sweetAlert.confirmButtonText") as string,
+                cancelButtonText: t("sweetAlert.cancelButtonText") as string,
+            }).fire().then((result) => {
+                if (result.isConfirmed) {
+                    AppPopupAlert({
+                        icon: 'success',
+                        title: t("sweetAlertSuccess.title") as string,
+                        confirmButtonText: t("sweetAlertSuccess.confirmButtonText") as string,
+                    }).fire().then(() => navigate('/profile'));
+                }
+            });
+        }
     }
-
     return {
         onChange,
         hasError,

--- a/src/hooks/useRegisterFamilyMembers.ts
+++ b/src/hooks/useRegisterFamilyMembers.ts
@@ -1,9 +1,8 @@
 import React from "react";
 import {useNavigate} from "react-router-dom";
-import Swal from "sweetalert2";
 import {useTranslation} from "react-i18next";
 import {namespaces} from "../i18n/i18n.constants";
-import {widthSwalCalculation} from "../helpers";
+import AppPopupAlert from "../components/atom/AppPopupAlert";
 
 const useRegisterFamilyMembers = () => {
     const {t} = useTranslation(namespaces.pages.registerFamilyMembers);
@@ -19,34 +18,17 @@ const useRegisterFamilyMembers = () => {
     };
 
     const handleWithoutFamilyMembers = () => {
-        Swal.fire({
+        AppPopupAlert({
+            icon: 'warning',
             title: t("sweetAlert.title") as string,
             text: t("sweetAlert.text") as string,
-            icon: "warning",
-            iconColor: "#EB5757",
-            showCancelButton: true,
-            buttonsStyling: false,
-            position: 'bottom',
-            padding: '1rem',
-            reverseButtons: true,
             confirmButtonText: t("sweetAlert.confirmButtonText") as string,
             cancelButtonText: t("sweetAlert.cancelButtonText") as string,
-            customClass: {
-                popup: "rounded-2xl",
-                actions: "flex gap-2 w-full",
-                title: "font-big-title text-secondary-color",
-                htmlContainer: "text-left font-text text-secondary-color",
-                confirmButton: "bg-primary-color hover-primary-color text-white rounded-2xl font-button w-2/5" +
-                    " focus:outline-none focus:ring-1 focus:ring-offset-1 focus-primary-color h-16",
-                cancelButton: "bg-warning-color hover-warning-color text-white rounded-2xl font-button w-2/5" +
-                    " focus:outline-none focus:ring-1 focus:ring-offset-1 focus-warning-color h-16",
-            },
-            width: widthSwalCalculation(parent.innerWidth),
-        }).then((result) => {
+        }).fire().then((result) => {
             if (result.isConfirmed) {
                 navigate("/register/referral");
             }
-        });
+        })
     };
 
 

--- a/src/hooks/useRegisterFamilyMembers.ts
+++ b/src/hooks/useRegisterFamilyMembers.ts
@@ -1,8 +1,13 @@
 import React from "react";
 import {useNavigate} from "react-router-dom";
+import Swal from "sweetalert2";
+import {useTranslation} from "react-i18next";
+import {namespaces} from "../i18n/i18n.constants";
 
 const useRegisterFamilyMembers = () => {
+    const {t} = useTranslation(namespaces.pages.registerFamilyMembers);
     const [familyMembers, setFamilyMembers] = React.useState([]);
+
     const navigate = useNavigate();
 
     const disableNext = familyMembers.length === 0;
@@ -12,11 +17,43 @@ const useRegisterFamilyMembers = () => {
         }
     };
 
+    const handleWithoutFamilyMembers = () => {
+        Swal.fire({
+            title: t("sweetAlert.title") as string,
+            text: t("sweetAlert.text") as string,
+            icon: "warning",
+            iconColor: "#EB5757",
+            showCancelButton: true,
+            buttonsStyling: false,
+            position: 'bottom',
+            padding: '1rem',
+            reverseButtons: true,
+            confirmButtonText: t("sweetAlert.confirmButtonText") as string,
+            cancelButtonText: t("sweetAlert.cancelButtonText") as string,
+            customClass: {
+                popup: "rounded-2xl",
+                actions: "flex gap-2 w-full",
+                title: "font-big-title text-secondary-color",
+                htmlContainer: "text-left font-text text-secondary-color",
+                confirmButton: "bg-primary-color hover-primary-color text-white rounded-2xl font-button w-2/5" +
+                    " focus:outline-none focus:ring-1 focus:ring-offset-1 focus-primary-color h-16",
+                cancelButton: "bg-warning-color hover-warning-color text-white rounded-2xl font-button w-2/5" +
+                    " focus:outline-none focus:ring-1 focus:ring-offset-1 focus-warning-color h-16",
+            },
+            width: parent.innerWidth < 768 ? '95%' : parent.innerWidth < 1024 ? '48%' : '35%',
+        }).then((result) => {
+            if (result.isConfirmed) {
+                navigate("/register/referral");
+            }
+        });
+    };
+
 
     return {
         familyMembers,
         setFamilyMembers,
         handleNextWithFamilyMembers,
+        handleWithoutFamilyMembers,
         disableNext
     };
 }

--- a/src/hooks/useRegisterFamilyMembers.ts
+++ b/src/hooks/useRegisterFamilyMembers.ts
@@ -3,6 +3,7 @@ import {useNavigate} from "react-router-dom";
 import Swal from "sweetalert2";
 import {useTranslation} from "react-i18next";
 import {namespaces} from "../i18n/i18n.constants";
+import {widthSwalCalculation} from "../helpers";
 
 const useRegisterFamilyMembers = () => {
     const {t} = useTranslation(namespaces.pages.registerFamilyMembers);
@@ -40,7 +41,7 @@ const useRegisterFamilyMembers = () => {
                 cancelButton: "bg-warning-color hover-warning-color text-white rounded-2xl font-button w-2/5" +
                     " focus:outline-none focus:ring-1 focus:ring-offset-1 focus-warning-color h-16",
             },
-            width: parent.innerWidth < 768 ? '95%' : parent.innerWidth < 1024 ? '48%' : '35%',
+            width: widthSwalCalculation(parent.innerWidth),
         }).then((result) => {
             if (result.isConfirmed) {
                 navigate("/register/referral");

--- a/src/i18n/pages/registerFamilyMembers.ts
+++ b/src/i18n/pages/registerFamilyMembers.ts
@@ -8,7 +8,7 @@ export const registerFamilyMembersEs = {
         title: 'Ningún familiar añadido',
         text: 'Si tienes familiares y no los añades, no contabilizarán para la asignación de alimentos.',
         confirmButtonText: 'Continuar',
-        cancelButtonText: 'Añadir familiar',
+        cancelButtonText: 'Cancelar',
     }
 }
 
@@ -22,6 +22,6 @@ export const registerFamilyMembersEn = {
         title: 'No family members added',
         text: 'If you have family members and you don’t add them, they won’t count towards food allocation.',
         confirmButtonText: 'Continue',
-        cancelButtonText: 'Add family member',
+        cancelButtonText: 'Cancel',
     }
 }

--- a/src/pages/RegisterFamilyMembers.tsx
+++ b/src/pages/RegisterFamilyMembers.tsx
@@ -9,11 +9,11 @@ import useRegisterFamilyMembers from "../hooks/useRegisterFamilyMembers";
 
 const RegisterFamilyMembers = () => {
     const {t} = useTranslation(namespaces.pages.registerFamilyMembers);
-    const {handleNextWithFamilyMembers, disableNext} = useRegisterFamilyMembers();
+    const {handleNextWithFamilyMembers, handleWithoutFamilyMembers, disableNext} = useRegisterFamilyMembers();
 
     return (
         <div className="flex h-screen flex-col justify-between p-8 page-bg text-secondary-color">
-            <div className="flex flex-col gap-8 self-center md:w-1/2 lg:w-1/3 w-full">
+            <div className="flex w-full flex-col gap-8 self-center md:w-1/2 lg:w-1/3">
                 <AppBackButton goTo="/register/id"/>
                 <div>
                     <h1 className="mb-4 text-1xl font-big-title">{t("title")}</h1>
@@ -25,9 +25,9 @@ const RegisterFamilyMembers = () => {
                     <p className="font-button text-primary-color">{t("addMember")}</p>
                 </Link>
             </div>
-            <div className="flex flex-col gap-4 self-center md:w-1/2 lg:w-1/3 w-full">
-                <p className="font-big-link text-center underline"
-                   onClick={() => console.log("Popup")}>{t("nextWithoutMembers")}</p>
+            <div className="flex w-full flex-col gap-4 self-center md:w-1/2 lg:w-1/3">
+                <p className="cursor-pointer text-center underline font-big-link"
+                   onClick={handleWithoutFamilyMembers}>{t("nextWithoutMembers")}</p>
                 <AppNextButton title={t("nextWithMembers")} disabled={disableNext}
                                onClick={handleNextWithFamilyMembers}/>
             </div>


### PR DESCRIPTION
## Description

This pull request adds a new feature for the "RegistrationFamilyMember" page. A confirmation popup that is open when users want to continue without adding family members.

## Changes

- Add a new page, "RegisterFamilyMembers," to the Router.
- Add i18n text for the "RegisterFamilyMembers" page.
- Add a hook to the "RegisterFamilyMembers" page.

## Checks

- [X] Add a confirmation popup on "RegisterFamilyMembersPopup" page with "Cancelar" and "Continuar" buttons.
- [X] Update all popups designs to align with Figma design specifications.
- [X] Updated documentation accordingly
- [X] "Cancelar" button keeps the user on screen 18.
- [X] "Continuar" button sends the user to page 22.

## Screenshots

- RegisterFamilyMembers popup:
![Screenshot from 2023-01-14 23-28-51](https://user-images.githubusercontent.com/101671573/212501882-9fe8b8fe-657a-432e-a898-a9905af3a307.png)


## Additional information

- Issue #33 

This branch was created from the branch _feature-18/user-adds-new-family-members-to-his-her-account_
URL: https://github.com/TheTributeCommunity/fesbal-frontend/pull/58