### PR TITLE
fix(build): Fix User props

### DIFF
--- a/src/components/molecules/LoginForm.tsx
+++ b/src/components/molecules/LoginForm.tsx
@@ -7,15 +7,11 @@ import {useTranslation} from "react-i18next";
 import AppFormInput from "../atom/AppFormInput";
 
 const LoginForm = () => {
-    const {user, onChange, hasError, onSubmit} = useLoginForm(
-        {
-            email: "",
-            password: ""
-        });
+    const {userEmail, userPassword, onChangeUserEmail, onChangeUserPassword, hasError, onSubmit} = useLoginForm();
     const {showPassword, toggleShowPassword} = useShowPassword();
     const {t: translate} = useTranslation(namespaces.pages.loginScreen);
 
-    const buttonDisabled = user.email.length < 6  || user.password.length < 3 || hasError;
+    const buttonDisabled = userEmail.length < 6  || userPassword.length < 3 || hasError;
 
     return (
         <form noValidate onSubmit={onSubmit} className="mt-8 flex w-full flex-col justify-between gap-4 self-center">
@@ -23,8 +19,8 @@ const LoginForm = () => {
                 <AppFormInput
                     label={translate("email")}
                     name="email"
-                    value={user.email}
-                    onChange={onChange}
+                    value={userEmail}
+                    onChange={(e) => onChangeUserEmail(e.target.value)}
                     placeholder={translate("email")}
                     hasError={hasError}
                 />
@@ -32,8 +28,8 @@ const LoginForm = () => {
                     <AppFormInput label={translate("password")}
                                   type={showPassword ? "text" : "password"}
                                   name="password"
-                                  value={user.password}
-                                  onChange={onChange}
+                                  value={userPassword}
+                                  onChange={(e) => onChangeUserPassword(e.target.value)}
                                   placeholder={translate("password")}
                                   hasError={hasError}
                                   toggleShowPassword={toggleShowPassword}

--- a/src/hooks/useLoginForm.ts
+++ b/src/hooks/useLoginForm.ts
@@ -3,23 +3,32 @@ import {useNavigate} from "react-router-dom";
 import UserProps from "../types/UserProps";
 import {AuthService} from "../services/auth-service";
 
-const useLoginForm = <T extends UserProps>(initialState: T) => {
-    const [user, setUser] = useState<T>(initialState);
+const useLoginForm = () => {
+    const [userEmail, setUserEmail] = useState<string>('');
+    const [userPassword, setUserPassword] = useState<string>('');
     const [hasError, setHasError] = useState<boolean>(false);
 
     const navigate = useNavigate();
-    const onChange = (e: ChangeEvent<HTMLInputElement>) => {
-        setUser({...user, [e.target.name]: e.target.value});
+    const onChangeUserEmail = (email: string) => {
+        setUserEmail(email);
+        setHasError(false);
+    }
+    const onChangeUserPassword = (password: string) => {
+        setUserPassword(password);
         setHasError(false);
     }
     const onSubmit = (e: FormEvent<HTMLFormElement>) => {
         e.preventDefault();
-        AuthService.signIn(user).then(() => navigate('/profile')).catch(() => setHasError(true))
+        AuthService.signIn(userEmail, userPassword)
+            .then(() => navigate('/profile'))
+            .catch(() => setHasError(true))
     }
 
     return {
-        onChange,
-        user,
+        userEmail,
+        userPassword,
+        onChangeUserEmail,
+        onChangeUserPassword,
         hasError,
         onSubmit,
     }

--- a/src/services/auth-service.ts
+++ b/src/services/auth-service.ts
@@ -35,10 +35,7 @@ export class AuthService {
         AuthService.auth = getAuth();
     }
 
-    public static signIn(user: userProps) {
-        if(!user.email){
-            throw new Error("Please, provide a valid email")
-        }
-        return signInWithEmailAndPassword(AuthService.auth, user.email, user.password)
+    public static signIn(email: string , password: string) {
+        return signInWithEmailAndPassword(AuthService.auth, email, password)
     }
 }

--- a/src/types/UserProps.ts
+++ b/src/types/UserProps.ts
@@ -1,5 +1,5 @@
 interface UserProps {
-    id?: string;
+    id: string;
     password: string;
     email?: string;
     fullName?: string;


### PR DESCRIPTION
<!--

Remember to refer to the CONTRIBUTING.md file before sending the PR

-->

## Description

npm run build was failing because UserProps id type had been changed to an undefined | string, I have to restore that to a string type.

## Changes
- Restore UserProps id to string type
- Remove UserProps type from LoginForm hook and use just plain password/email as string variables

NOTE: Password/email login is going to be removed by this PR https://github.com/TheTributeCommunity/fesbal-frontend/pull/88 so don't give it too much thought to the password/email code, is going to be substituted by phone number in the next hours I hope