### PR TITLE
Feature 98/fix success screen styles

### DIFF
--- a/src/components/atom/RegisterPersonalDataItem.tsx
+++ b/src/components/atom/RegisterPersonalDataItem.tsx
@@ -2,8 +2,8 @@ import PersonalDataItemProps from "../../types/PersonalDataItemProps";
 
 const RegisterPersonalDataItem = (personalData: PersonalDataItemProps, index: number) => {
     return (
-        <li key={index} className="flex gap-2 items-center">
-            <p className="font-mini-title">{personalData.title}:</p>
+        <li key={index} className={`col-span-${personalData.span} py-1`}>
+            <p className="font-label text-primary-color">{personalData.title}</p>
             <p className="font-text">{personalData.value}</p>
         </li>
     );

--- a/src/i18n/pages/registerRequestSent.ts
+++ b/src/i18n/pages/registerRequestSent.ts
@@ -3,10 +3,10 @@ export const registerRequestSentEs = {
     fullName: "Nombre y apellidos",
     id: "Documento de identidad",
     birthDate: "Fecha de nacimiento",
-    email: "Correo electrónico",
+    email: "Email",
     phone: "Teléfono",
     password: "Contraseña",
-    familyMembers: "Miembros de la unidad familiar",
+    familyMembers: "Miembros unidad familiar",
     next: 'Cerrar aplicación'
 };
 

--- a/src/pages/RegisterRequestSent.tsx
+++ b/src/pages/RegisterRequestSent.tsx
@@ -20,44 +20,50 @@ const RegisterRequestSent = () => {
             {
                 title: translate('fullName'),
                 value: user.fullName,
+                span: 2
             },
             {
                 title: translate('id'),
-                value: user.id
+                value: user.id,
+                span: 1
             },
             {
                 title: translate('birthDate'),
                 value: user.birthDate,
+                span: 1
             },
             {
                 title: translate('email'),
                 value: user.email,
                 hasEditButton: true,
                 goTo: `/profile/edit-email`,
+                span: 1
             },
             {
                 title: translate('phone'),
                 value: user.phone,
+                span: 1
             },
             {
-                title: 'Miembros de la familia',
+                title: 'Miembros unidad familiar',
                 value: getFamilyMembers(user.id)?.length.toString() || '0',
+                span: 2
             }
         ];
     };
 
     return (
-        <div className="flex h-screen items-center justify-center p-8 bg-primary-color text-secondary-color">
+        <div className="h-screen flex flex-col justify-end bg-primary-color px-4 pb-4">
             <div className="app-logo">
                 <LogoFesbalWhiteIcon/>
             </div>
-            <div className="mt-8 flex w-full flex-col gap-4 self-end rounded-xl bg-white p-8 md:w-1/2 lg:w-1/3">
+            <div className="mx-auto w-full md:w-1/2 lg:w-1/3 px-8 pb-4 text-center bg-white rounded-xl text-secondary-color z-10">
                 <RequestSentIcon/>
-                <div className="flex flex-col items-center justify-center">
-                    <h1 className="mb-5 font-big-title">{translate("title")}</h1>
-                    <ul className="flex flex-col gap-0.5">
+                <div className="flex flex-col">
+                    <h1 className="mb-4 font-big-title">{translate("title")}</h1>
+                    <ul className="grid grid-cols-2 gap-3 pb-2 text-left justify-between">
                         {getPersonalData().map((item, index) => (
-                            <RegisterPersonalDataItem title={item.title} value={item.value} key={index}/>
+                            <RegisterPersonalDataItem title={item.title} value={item.value} span={item.span} key={index}/>
                         ))}
                     </ul>
                 </div>

--- a/src/types/PersonalDataItemProps.ts
+++ b/src/types/PersonalDataItemProps.ts
@@ -3,7 +3,7 @@ interface PersonalDataItemProps {
     value?: string;
     hasEditButton?: boolean;
     goTo?: string;
-    span: number;
+    span?: number;
 }
 
 export default PersonalDataItemProps;

--- a/src/types/PersonalDataItemProps.ts
+++ b/src/types/PersonalDataItemProps.ts
@@ -3,6 +3,7 @@ interface PersonalDataItemProps {
     value?: string;
     hasEditButton?: boolean;
     goTo?: string;
+    span: number;
 }
 
 export default PersonalDataItemProps;


### PR DESCRIPTION
<!--

Remember to refer to the CONTRIBUTING.md file before sending the PR

-->

## Description

Fix styles in the succes screen [[18]](https://www.figma.com/file/JBz3rPyu058jqJMWKPtwgm/Version-0.5---FESBAL?node-id=1239%3A10685&t=efaDh4Mt6EOW3XLg-0) to match the figma design

Now it looks like this:

![image](https://user-images.githubusercontent.com/122277388/215084743-38ad8dc2-7b34-4a81-9dc5-861006ec8543.png)

## Changes

- Changes in styles to fix the new figma design, I had to add a grid and adjust the margins and font size 

## Checks

- [ ] Project Builds
- [ ] Project passes tests and checks
- [ ] Updated documentation accordingly


## Additional information
The screen with the changes:
![image](https://user-images.githubusercontent.com/122277388/215084383-7482d578-dc58-40c7-92d6-ca3f33d16479.png)