### PR TITLE
FIX: fix font declaration typo for 'RobotoFlex'

### DIFF
--- a/src/styles/variables.scss
+++ b/src/styles/variables.scss
@@ -25,4 +25,4 @@ $page-bg: $bg-linear;
 $shadow-color: 0px 2px 4px rgba(0, 46, 93, 0.08);
 $primary-color-light: $alice-blue;
 
-$main-font: 'RobotoFlex', sans-serif;
+$main-font: 'Roboto Flex', sans-serif;


### PR DESCRIPTION
<!--

Remember to refer to the CONTRIBUTING.md file before sending the PR

-->

## Description

Discovered why many font's weren't with the right font family.
This PR fixes font declaration from 'RobotoFlex' to  'Roboto Flex'

## Changes

Just fixing the typo