### PR TITLE
FESBAL-9: accepts only images and PDFs

### DIFF
--- a/src/components/molecules/ReferralNoFileUploaded.tsx
+++ b/src/components/molecules/ReferralNoFileUploaded.tsx
@@ -9,7 +9,7 @@ const ReferralNoFileUploaded = ({
     return (
         <div>
             <div className="flex flex-col place-content-center">
-                <input type="file" id="file" className="hidden" onChange={handleFileChange} ref={inputRef}/>
+                <input type="file" accept="image/*,.pdf" id="file" className="hidden" onChange={handleFileChange} ref={inputRef}/>
                 <button className="text-center font-text font-roboto-flex font-semibold text-sm underline"
                     onClick={() => handleClick(inputRef)}>
                     {upload}


### PR DESCRIPTION
<!--

Remember to refer to the CONTRIBUTING.md file before sending the PR

-->

## Description

The referral upload dialog should only allow the user to select images or pdfs.

## Changes

<!-- 

Describe changes you have made:

- Referral file upload now limits file types to images and PDFs

-->

## Checks

- [x] Project Builds
- [n/a] Project passes tests and checks
- [n/a] Updated documentation accordingly

<!-- 
## Additional information

Here you can add any additional information about your PR

For example:

- Reference issue number

- Mention any changes or concerns you may have about this PR

- Reference links to any resource that help clarifying the intent and goals of the change.

-->
