### PR TITLE
FESBAL-11: fixed profile family member title spacing

### DIFF
--- a/src/components/atom/FamilyMemberCard.tsx
+++ b/src/components/atom/FamilyMemberCard.tsx
@@ -1,10 +1,10 @@
-import { useTranslation } from "react-i18next";
-import { Link } from "react-router-dom";
-import { namespaces } from "../../i18n/i18n.constants";
-import DeleteIcon from "../icons/DeleteIcon";
-import EditIcon from "../icons/EditIcon";
-import {Relative} from "../../models/relative";
-import {RecipientUser} from "../../models/recipient-user";
+import { useTranslation } from 'react-i18next'
+import { Link } from 'react-router-dom'
+import { namespaces } from '../../i18n/i18n.constants'
+import DeleteIcon from '../icons/DeleteIcon'
+import EditIcon from '../icons/EditIcon'
+import {Relative} from '../../models/relative'
+import {RecipientUser} from '../../models/recipient-user'
 
 interface FamilyMemberCardProps {
     person: RecipientUser | Relative
@@ -14,7 +14,7 @@ interface FamilyMemberCardProps {
 const isRecipientUser = (p: RecipientUser | Relative): p is RecipientUser => (p as RecipientUser).phone !== undefined
 
 const FamilyMemberCard = ({person, allowEdit = false}: FamilyMemberCardProps): JSX.Element => {
-    const {t: translate} = useTranslation(namespaces.pages.registerFamilyMembers);
+    const {t: translate} = useTranslation(namespaces.pages.registerFamilyMembers)
     
     return (
         <div className="w-full flex flex-col gap-4 bg-white shadow-md rounded-xl p-4 self-center">
@@ -25,8 +25,8 @@ const FamilyMemberCard = ({person, allowEdit = false}: FamilyMemberCardProps): J
                 </div>
                 {!isRecipientUser(person) && allowEdit &&
                 <div className="flex flex-row align-center items-center gap-4">
-                    <Link to={""}><EditIcon /></Link>
-                    <Link to={""}><DeleteIcon /></Link>
+                    <Link to={''}><EditIcon /></Link>
+                    <Link to={''}><DeleteIcon /></Link>
                 </div>}
             </div>
             <div className="w-full border border-[#F2FBFF] border-solid"></div>
@@ -56,4 +56,4 @@ const FamilyMemberCard = ({person, allowEdit = false}: FamilyMemberCardProps): J
     )
 }
 
-export default FamilyMemberCard;
+export default FamilyMemberCard

--- a/src/pages/ProfileScreen.tsx
+++ b/src/pages/ProfileScreen.tsx
@@ -50,14 +50,16 @@ const ProfileScreen = () => {
                         <ProfilePersonalDataItem key={index} personalData={personalData} index={index} itemClassName="px-8"/>
                     ))}
                 </ul>
-                <div className="flex flex-row items-center gap-2 px-8 font-bold mt-3">
+                <div className="flex flex-row items-center gap-2 px-8 font-bold my-3">
                     <FamilyMembersIcon/>
                     <h2 className="font-mini-title text-secondary-color">{translate('familyMembers')}</h2>
                     <div className="ml-auto"></div>
                 </div>
                 {familyMembers.map((familyMember, index) => 
                     <div className="flex flex-col gap-4 pb-2" key={index}>
-                        <span className="text-primary-color font-roboto-flex font-bold text-base leading-5">{translate('familyMember', {ns: 'pages.registerFamilyMembers'})} {index+1}</span>
+                        <div className="px-8">
+                            <span className="text-primary-color font-roboto-flex font-bold text-base leading-5">{translate('familyMember', {ns: 'pages.registerFamilyMembers'})} {index+1}</span>
+                        </div>
                         <FamilyMemberCard person={familyMember} />
                     </div>)}
             </div>


### PR DESCRIPTION
<!--

Remember to refer to the CONTRIBUTING.md file before sending the PR

-->

## Description

Profile family member title spacing has been aligned with the rest of the screen elements.

## Changes

- Aligned family member title in profile screen
- Reformatted some files with new formatter rules

## Checks

- [x] Project Builds
- [n/a] Project passes tests and checks
- [n/a] Updated documentation accordingly


## Additional information

<img width="597" alt="image" src="https://user-images.githubusercontent.com/24732678/228600237-4cedef18-ab35-49ce-b4b4-d4abb13d6edf.png">

