### PR TITLE
Websockets reconnect with new auth

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -44,6 +44,7 @@ import ProtectedLayout from './components/atom/ProtectedLayout'
 import Spinner from './components/atom/Spinner'
 import BlankStage from './components/atom/BlankStage'
 import { addLocale } from 'primereact/api'
+import { BoosterClient } from './services/booster-service'
 
 addLocale('en', {
     firstDayOfWeek: 1,
@@ -61,11 +62,12 @@ const App = () => {
                 const userType = user.providerData[0].providerId === 'phone' ? UserType.RECIPIENT : UserType.ENTITY
                 setLoggedUserType(userType)
                 setFirebaseUser(user)
-                user.getIdToken().then(token => localStorage.setItem('token', token))
+                user.getIdToken().then(token => localStorage.setItem('token', token)).then(() => { BoosterClient.resetStore()})
             } else {
                 setLoggedUserType(undefined)
                 setFirebaseUser(undefined)
                 localStorage.removeItem('token')
+                localStorage.removeItem('userGuest')
             }
         })
     }, [])


### PR DESCRIPTION
<!--

Remember to refer to the CONTRIBUTING.md file before sending the PR

-->

## Description

Websocket connection with backend now reauthenticates whenever the token changes

## Changes

- Apollo client connections rebuilt when there are authentication changes, websockets now work as long as authenticated

## Checks

- [x] Project Builds
- [n/a] Project passes tests and checks
- [n/a] Updated documentation accordingly

<!-- 
## Additional information

Here you can add any additional information about your PR

For example:

- Reference issue number

- Mention any changes or concerns you may have about this PR

- Reference links to any resource that help clarifying the intent and goals of the change.

-->
