### PR TITLE
relatives updated with subscriptions

### DIFF
--- a/src/components/molecules/ReferralFileUploaded.tsx
+++ b/src/components/molecules/ReferralFileUploaded.tsx
@@ -1,4 +1,3 @@
-import CloseIcon from '../icons/CloseIcon'
 import ReferralFileUploadedProps from '../../types/ReferralFileUploadProps'
 import DeleteIcon from '../icons/DeleteIcon'
 

--- a/src/hooks/useRegisterFamilyMembers.ts
+++ b/src/hooks/useRegisterFamilyMembers.ts
@@ -4,17 +4,24 @@ import { useTranslation } from 'react-i18next'
 import { namespaces } from '../i18n/i18n.constants'
 import AppPopupAlert from '../components/atom/AppPopupAlert'
 import { RecipientUser } from '../models/recipient-user'
-import { RecipientUserService } from '../services/recipient-user-service'
+import { RecipientUserService, SUBSCRIBE_TO_RECIPIENT_USER } from '../services/recipient-user-service'
 import { Relative } from '../models/relative'
 import { AppRoute } from '../enums/app-route'
 import { UsersContext } from '../contexts/usersContext'
 import { RelativeService } from '../services/relative-service'
+import { useSubscription } from '@apollo/client'
 
 const useRegisterFamilyMembers = () => {
     const { t: translate } = useTranslation(namespaces.pages.registerFamilyMembers)
     const [familyMembers, setFamilyMembers] = useState<Relative[]>([])
     const [user, setUser] = useState<RecipientUser>()
     const { firebaseUser } = useContext(UsersContext)
+    useSubscription(SUBSCRIBE_TO_RECIPIENT_USER,
+        {
+            variables: { id: user?.id ?? '' },
+            skip: user ? false : true,
+            onSubscriptionData: () => fetchRelatives(user?.id ?? '').then(relatives => setFamilyMembers(relatives))
+        })
 
     useEffect(() => {
         if (firebaseUser) {
@@ -22,12 +29,21 @@ const useRegisterFamilyMembers = () => {
                 .then(recipientUser => {
                     setUser(recipientUser)
                     recipientUser.relativesIds &&
-                        RelativeService.getAllByRecipientUserId(firebaseUser.uid)
+                        fetchRelatives(firebaseUser.uid)
                             .then(relatives => setFamilyMembers(relatives))
                 })
                 .catch(e => console.log(e))
         }
     }, [firebaseUser])
+
+    const fetchRelatives = async (id: string): Promise<Relative[]> => {
+        const relatives = await RelativeService.getAllByRecipientUserId(id)
+            .catch(e => {
+                console.log(e)
+                return []
+            })
+        return relatives
+    }
 
     const navigate = useNavigate()
 

--- a/src/services/recipient-user-service.ts
+++ b/src/services/recipient-user-service.ts
@@ -223,3 +223,11 @@ const DELETE_RECIPIENT_USER = gql`
     DeleteRecipientUser(input: $userToDelete)
   }
 `
+
+export const SUBSCRIBE_TO_RECIPIENT_USER = gql`
+    subscription ($id: ID!) {
+        RecipientUserReadModel(id: $id) {
+            relativesIds
+        }
+    }
+`


### PR DESCRIPTION
<!--

Remember to refer to the CONTRIBUTING.md file before sending the PR

-->

## Description

Using subscriptions, we update the relatives shown on screen whenever we receive an update to the read model.

It can be done more efficiently, but we need changes in the backend to fill in a `relatives` field with actual Relative objects, instead of only filling in the `relativeIds` field.

## Changes

<!-- 

Describe changes you have made:

- Added recipient user subscription GQL query
- Updated relatives shown on register family members screen based on incoming subscription events

-->

## Checks

- [x] Project Builds
- [n/a] Project passes tests and checks
- [n/a] Updated documentation accordingly

<!-- 
## Additional information

Here you can add any additional information about your PR

For example:

- Reference issue number

- Mention any changes or concerns you may have about this PR

- Reference links to any resource that help clarifying the intent and goals of the change.

-->
